### PR TITLE
Fixed outdated offer

### DIFF
--- a/Sponsors.md
+++ b/Sponsors.md
@@ -14,7 +14,6 @@ The list below describes what our catering sponsor gets in return:
 
 * leaflets (on table at entrance),
 * online banner on DevStaff website (with back-link do-follow),
-* online banner on DevStaff Meetup.com group page,
 * "Thank-you" message by organizers during Meetup (not by company),
 * sponsor's slide in DevStaff Welcome presentation,
 * facebook page post.


### PR DESCRIPTION
meetup.com has changed its offering and we can no longer (unfortunately) add sponsors logos on the meetup page